### PR TITLE
Fix container size ( > 4) for Kong Cluster

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -9,7 +9,7 @@ spec:
   minReadySeconds: 30
   strategy:
     type: RollingUpdate
-  replicas: 1
+  replicas: 5
   template:
     metadata:
       name: kong


### PR DESCRIPTION
## WHY

1 container can not be cluster...
Fix container size for Kong Cluster.
## WHAT
- 1 -> 5 containers.
