### PR TITLE
Update offical image path

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         name: kong
     spec:
       containers:
-      - image: mashape/kong:0.9.0
+      - image: kong:0.9.0
         name: kong
         ports:
           - containerPort: 8000


### PR DESCRIPTION
## WHY

Fix offical image path

- :no_good_man:  

```
$ docker pull mashape/kong:0.9.0
Error response from daemon: repository mashape/kong not found: does not exist or no pull access
```

- :ok_man: 

```
$ docker pull kong:0.9.0
0.9.0: Pulling from library/kong
b4fc80d8f477: Pull complete 
0d62dc86b7a3: Pull complete 
9954873b058d: Pull complete 
a0eaf38f552b: Pull complete 
Digest: sha256:aaa71959e8ffcd9b80db15d9a620feb3d90147dfba466e3fae16b05a0ddb76b1
Status: Downloaded newer image for kong:0.9.0
```

